### PR TITLE
CORE-4226 - JSON unstructured format in predict outputs

### DIFF
--- a/unstructured_sg/utils.py
+++ b/unstructured_sg/utils.py
@@ -18,7 +18,7 @@ def load_json(path: Path) -> Any:
 
 def dump_json(path: Path, data: Any) -> None:
     with open(path, "w") as file:
-        json.dump(data, file)
+        json.dump(data, file, indent=4)
 
 
 def load_txt_with_json(path: Path) -> Any:


### PR DESCRIPTION
PR reformats JSON outputs in _unstructured_predict.py_ script to be aligned with unstructured output format.

Layout format was based on:
s3://utic-comparative-metrics/mini-holistic/textract/simplified_layout

Assumptions:
* `element_id` is set to `None` 
* `layout_width` and `layout_height` are set to equal 1. Bbox values are reformatted accordingly to range between 0. and 1.0 (there are some edge cases when they can be greater than 1. due to inner workings of the model)